### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: node_js
 node_js:
   - "4.0"
 install:


### PR DESCRIPTION
Travis was defaulting to node 0.10 when language: node_js was not specified.
