### PR TITLE
fix: support freebsd

### DIFF
--- a/lib/psaux.js
+++ b/lib/psaux.js
@@ -1,7 +1,10 @@
 const execa = require('execa');
 const os = require('os');
 
-if (os.platform() != "win32") {
+const platform = os.platform()
+if (platform === 'freebsd') {
+  module.exports = getFreeBSDProcess;
+} else if (platform != "win32") {
   module.exports = getProcess;
 } else {
   module.exports = getWinProcess;
@@ -43,6 +46,22 @@ function parseWinProcesses(list, ps) {
   });
 
   return list;
+}
+
+function getFreeBSDProcess(options) {
+  return new Promise((resolve, reject) => {
+    execa('ps', ['auxww']).then(result => {
+      var processes = result.stdout.split('\n');
+
+      //Remove header
+      processes.shift();
+      processes = processes.reduce(parseProcesses, []);
+
+      processes.query = query;
+
+      resolve(processes);
+    }); 
+  });
 }
 
 function getProcess(options) {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "os": [
     "darwin",
+    "freebsd",
     "linux",
     "win32"
   ],


### PR DESCRIPTION
This PR modifies the `package.json` file to indicate support for FreeBSD, so that installation doesn't fail. The code did not require other changes to function on FreeBSD.